### PR TITLE
Migrate the PD commons-compress fork to use AWS CodeArtifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,28 +99,46 @@ Brotli, Zstandard and ar, cpio, jar, tar, zip, dump, 7z, arj.
     <url>https://issues.apache.org/jira/browse/COMPRESS</url>
   </issueManagement>
 
-  <distributionManagement>
-    <repository>
-      <id>pep01.pepperdata.com</id>
-      <name>pep01.pepperdata.com-releases</name>
-      <url>http://pep01.pepperdata.com:8081/artifactory/libs-release-local</url>
-    </repository>
-    <snapshotRepository>
-      <id>pep01.pepperdata.com</id>
-      <name>pep01.pepperdata.com-snapshots</name>
-      <url>http://pep01.pepperdata.com:8081/artifactory/libs-snapshot-local</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <repositories>
     <repository>
       <id>central</id>
-      <url>http://pep01.pepperdata.com:8081/artifactory/repo</url>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
     </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <distributionManagement>
+    <repository>
+      <id>pepperdata-pd-artifactory</id>
+      <name>PD CodeArtifact Proxy</name>
+      <url>http://codeartifact.dev.pepperdata.com:8888/pd-artifactory/</url>
+    </repository>
+    <snapshotRepository>
+      <id>pepperdata-pd-artifactory-snapshot</id>
+      <name>PD CodeArtifact Snapshot Proxy</name>
+      <url>http://codeartifact.dev.pepperdata.com:8888/pd-artifactory-snapshot/</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
### Description

As the title says.  This addresses https://github.com/pepperdata/development-backlog/issues/3465.

#### IMPORTANT
This change is being made to the `commons-compress-1.26.2` branch of the `master` branch in the repo `pepperdata/commons-compress`.  Please refer to https://github.com/pepperdata/commons-compress/blob/commons-compress-1.26.2/README.md for further details. 

All changes to our fork should be made in the `pepperdata/commons-compress` repo, and _never_ attempted with the original `apache/commons-compress` repo!

### Tests Conducted
```
# This project requires at least maven v. 3.6.3, which is assumed to be located as follows:
$ /usr/local/apache-maven-3.6.3/bin/mvn clean package
```
The above PASSES on both MacOS and Linux x86-64.
